### PR TITLE
Add ALTCHA_ENABLED variable to disable altcha checking

### DIFF
--- a/django_altcha/__init__.py
+++ b/django_altcha/__init__.py
@@ -27,6 +27,7 @@ __version__ = "0.2.0"
 VERSION = __version__
 
 # Get the ALTCHA_HMAC_KEY from the settings, or generate one if not present.
+ALTCHA_ENABLED = getattr(settings, "ALTCHA_ENABLED", True)
 ALTCHA_HMAC_KEY = getattr(settings, "ALTCHA_HMAC_KEY", secrets.token_hex(32))
 ALTCHA_JS_URL = getattr(settings, "ALTCHA_JS_URL", "/static/altcha/altcha.min.js")
 
@@ -193,6 +194,10 @@ class AltchaField(forms.Field):
 
     def validate(self, value):
         """Validate the CAPTCHA token and verify its authenticity."""
+        # skip validation if altcha is disabled altogether
+        if not ALTCHA_ENABLED:
+            return
+
         super().validate(value)
 
         if not value:


### PR DESCRIPTION
In some development use cases we found it useful to turn of checking of Altcha fields; examples include local development or automated testing. To this end, this PR introduces a variable `ALTCHA_ENABLED`, defaulting to True, that allows to skip the ALTCHA checks. Example usage includes turning of the check of altcha fields when testing the business logic of forms guarded with django-altcha using a decorator such as `@override_settings(ALTCHA_ENABLED=False)`.

I chose to call the variable `ALTCHA_ENABLED`, as I personally prefer this over the double-negation that is implicit with variable names such as `SKIP_ALTCHA_VERIFICATION`. 

I did not get around to adding tests for this feature yet, as I did not immediately manage to get the tests to run.