### PR TITLE
Add the ``ALTCHA_HMAC_KEY`` setup as part of the installation #15

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+v0.3.0 (unreleased)
+-------------------
+
+- Add the ``ALTCHA_HMAC_KEY`` setup as part of the installation.
+  A DeprecationWarning is raised when the ``ALTCHA_HMAC_KEY`` is not explicitly defined.
+  Providing the ``ALTCHA_HMAC_KEY`` will be mandatory in future release.
+  https://github.com/aboutcode-org/django-altcha/issues/15
+
 v0.2.0 (2025-06-17)
 -------------------
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,22 @@ requiring additional configuration.
    ]
    ```
 
+3. **Set your secret HMAC key:**
+   
+   This key is used to HMAC-sign ALTCHA challenges and **must be kept secret**.
+   Treat it like a password: use a secure, 64-character hex string.
+
+   Update your Django project's `settings.py`:
+
+   ```python
+   ALTCHA_HMAC_KEY="your_secret_hmac_key"
+   ```
+
+> [!NOTE]
+> You can generate a new secured HMAC key using:
+> ``python -c "import secrets; print(secrets.token_hex(64))"``
+
+
 ## Usage
 
 ### Adding the CAPTCHA Field to Your Form

--- a/django_altcha/__init__.py
+++ b/django_altcha/__init__.py
@@ -9,6 +9,7 @@ import base64
 import datetime
 import json
 import secrets
+import warnings
 
 from django import forms
 from django.conf import settings
@@ -26,8 +27,21 @@ import altcha
 __version__ = "0.2.0"
 VERSION = __version__
 
-# Get the ALTCHA_HMAC_KEY from the settings, or generate one if not present.
-ALTCHA_HMAC_KEY = getattr(settings, "ALTCHA_HMAC_KEY", secrets.token_hex(32))
+ALTCHA_HMAC_KEY = getattr(settings, "ALTCHA_HMAC_KEY", None)
+if not ALTCHA_HMAC_KEY:
+    warnings.warn(
+        (
+            "ALTCHA_HMAC_KEY is not set in settings. "
+            "A random key is being generated, which is insecure and "
+            "may lead to signature mismatches in multi-worker deployments. "
+            "This fallback behavior will be removed in a future release. "
+            "Set ALTCHA_HMAC_KEY in your Django settings."
+        ),
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    ALTCHA_HMAC_KEY = secrets.token_hex(32)
+
 ALTCHA_JS_URL = getattr(settings, "ALTCHA_JS_URL", "/static/altcha/altcha.min.js")
 
 # Challenge expiration duration in milliseconds.

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -1,33 +1,46 @@
 Installation
 ============
 
-Installation Steps
-------------------
-
 1. **Install the package:**
 
-   .. code-block:: bash
+.. code-block:: bash
 
-       pip install django-altcha
+    pip install django-altcha
 
-2. **Add to `INSTALLED_APPS`:**
+2. **Add to INSTALLED_APPS:**
 
-   Update your Django project's `settings.py`:
+Update your Django project's ``settings.py``:
 
-   .. code-block:: python
+.. code-block:: python
 
-       INSTALLED_APPS = [
-           # Other installed apps
-           "django_altcha",
-       ]
+    INSTALLED_APPS = [
+        # Other installed apps
+        "django_altcha",
+    ]
+
+3. **Set your secret HMAC key:**
+
+This key is used to HMAC-sign ALTCHA challenges and **must be kept secret**.
+
+**Treat it like a password**: use a secure, 64-character hex string.
+
+Update your Django project's ``settings.py``:
+
+.. code-block:: python
+
+    ALTCHA_HMAC_KEY="your_secret_hmac_key"
+
+.. note::
+    You can generate a new secured HMAC key using:
+    ``python -c "import secrets; print(secrets.token_hex(64))"``
 
 Usage
------
+=====
 
 Adding the CAPTCHA Field to Your Form
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To add the Altcha CAPTCHA field to a Django form, import `AltchaField` and add it to
+To add a Altcha CAPTCHA field to a Django form, import ``AltchaField`` and add it to
 your form definition:
 
 .. code-block:: python
@@ -41,7 +54,7 @@ your form definition:
 Configuration Options
 ---------------------
 
-You can pass configuration options to `AltchaField` that are supported by Altcha.
+You can pass configuration options to ``AltchaField`` that are supported by Altcha.
 These options are documented at
 `Altcha's website integration guide <https://altcha.org/docs/website-integration/>`_.
 

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -3,3 +3,4 @@ INSTALLED_APPS = [
 ]
 DATABASES = {"default": {"ENGINE": "django.db.backends.sqlite3"}}
 ROOT_URLCONF = "tests.urls"
+ALTCHA_HMAC_KEY = "altcha-insecure-hmac-0123456789abcdef"


### PR DESCRIPTION
A DeprecationWarning is raised when the ``ALTCHA_HMAC_KEY`` is not explicitly defined.
  Providing the ``ALTCHA_HMAC_KEY`` will be mandatory in future release.