### PR TITLE
chore: set explicit workflow permissions and pin down actions

### DIFF
--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -1,24 +1,28 @@
 name: CI Documentation
 
-on: [push, pull_request]
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - main
 
 jobs:
   build:
     runs-on: ubuntu-24.04
-
-    strategy:
-      max-parallel: 4
-      matrix:
-        python-version: [3.12]
+    permissions:
+      contents: read
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
-          python-version: ${{ matrix.python-version }}
+          persist-credentials: false  # do not keep the token around
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: 3.12
 
       - name: Install Dependencies
         run:  pip install --editable .[docs]

--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -1,16 +1,4 @@
-name: Create library release archives, create a GH release and publish PyPI wheel and sdist on tag in main branch
-
-
-# This is executed automatically on a tag in the main branch
-
-# Summary of the steps:
-# - build wheels and sdist
-# - upload wheels and sdist to PyPI
-# - create gh-release and upload wheels and dists there
-# TODO: smoke test wheels and sdist
-# TODO: add changelog to release text body
-
-# WARNING: this is designed only for packages building as pure Python wheels
+name: Create a GH release and publish PyPI wheel and sdist
 
 on:
   workflow_dispatch:
@@ -22,11 +10,17 @@ jobs:
   build-pypi-distribs:
     name: Build and publish library to PyPI
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false  # do not keep the token around
+
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: 3.12
 
@@ -37,7 +31,7 @@ jobs:
         run: python -m build --sdist --wheel --outdir dist/
 
       - name: Upload built archives
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
         with:
           name: pypi_archives
           path: dist/*
@@ -48,37 +42,40 @@ jobs:
     needs:
       - build-pypi-distribs
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write
 
     steps:
       - name: Download built archives
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3  # v8.0.0
         with:
           name: pypi_archives
           path: dist
 
       - name: Create GH release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b  # v2.5.0
         with:
           draft: false
           generate_release_notes: true
           files: dist/*
-
 
   create-pypi-release:
     name: Create PyPI release
     needs:
       - create-gh-release
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
 
     steps:
       - name: Download built archives
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3  # v8.0.0
         with:
           name: pypi_archives
           path: dist
 
       - name: Publish to PyPI
         if: startsWith(github.ref, 'refs/tags')
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e  # v1.13.0
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   test:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
 
     strategy:
       max-parallel: 4
@@ -17,10 +19,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false  # do not keep the token around
 
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
 


### PR DESCRIPTION
## Changes

- Set explicit permissions
- Pin down all external actions to an exact commit
- Do not persist-credentials after the checkout