### PR TITLE
chore: rework the pypi-release workflow to use trusted publishing

### DIFF
--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -1,4 +1,4 @@
-name: Create a GH release and publish PyPI wheel and sdist
+name: Build Python distributions, publish on PyPI, and create a GH release
 
 on:
   workflow_dispatch:
@@ -7,8 +7,8 @@ on:
       - "v*.*.*"
 
 jobs:
-  build-pypi-distribs:
-    name: Build and publish library to PyPI
+  build-python-dist:
+    name: Build Python distributions
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
-          python-version: 3.12
+          python-version: 3.14
 
       - name: Install pypa/build
         run: python -m pip install build --user
@@ -30,27 +30,52 @@ jobs:
       - name: Build a binary wheel and a source tarball
         run: python -m build --sdist --wheel --outdir dist/
 
-      - name: Upload built archives
+      - name: Upload package distributions as GitHub workflow artifacts
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
         with:
-          name: pypi_archives
-          path: dist/*
+          name: python-package-distributions
+          path: dist/
 
+  # Only set the id-token: write permission in the job that does publishing, not globally.
+  # Also, separate building from publishing — this makes sure that any scripts
+  # maliciously injected into the build or test environment won't be able to elevate
+  # privileges while flying under the radar.
+  pypi-publish:
+    name: Upload package distributions to PyPI
+    if: startsWith(github.ref, 'refs/tags/')  # only publish to PyPI on tag pushes
+    needs:
+      - build-python-dist
+    runs-on: ubuntu-24.04
+    environment:
+      name: pypi
+      url: https://pypi.org/p/django-altcha
+    permissions:
+      id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
+
+    steps:
+      - name: Download package distributions
+        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3  # v8.0.0
+        with:
+          name: python-package-distributions
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e  # v1.13.0
 
   create-gh-release:
-    name: Create GH release
+    name: Create GitHub release
     needs:
-      - build-pypi-distribs
+      - build-python-dist
     runs-on: ubuntu-24.04
     permissions:
       contents: write
 
     steps:
-      - name: Download built archives
+      - name: Download package distributions
         uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3  # v8.0.0
         with:
-          name: pypi_archives
-          path: dist
+          name: python-package-distributions
+          path: dist/
 
       - name: Create GH release
         uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b  # v2.5.0
@@ -58,24 +83,3 @@ jobs:
           draft: false
           generate_release_notes: true
           files: dist/*
-
-  create-pypi-release:
-    name: Create PyPI release
-    needs:
-      - create-gh-release
-    runs-on: ubuntu-24.04
-    permissions:
-      contents: read
-
-    steps:
-      - name: Download built archives
-        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3  # v8.0.0
-        with:
-          name: pypi_archives
-          path: dist
-
-      - name: Publish to PyPI
-        if: startsWith(github.ref, 'refs/tags')
-        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e  # v1.13.0
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
- Remove the need for PYPI_API_KEY to publish the packages