### PR TITLE
Serve JS libs with static templatetag instead of hardcoded url

### DIFF
--- a/django_altcha/conf.py
+++ b/django_altcha/conf.py
@@ -17,6 +17,8 @@ final project configuration.
 
 from django.conf import settings
 
+from django_altcha.utils import lazy_static
+
 _DEFAULTS = {
     # Set to `False` to skip Altcha validation altogether.
     "ALTCHA_VERIFICATION_ENABLED": True,
@@ -24,10 +26,10 @@ _DEFAULTS = {
     "ALTCHA_HMAC_KEY": None,
     # URL of the Altcha JavaScript file.
     # Defaults to the bundled django-altcha file.
-    "ALTCHA_JS_URL": "/static/altcha/altcha.min.js",
+    "ALTCHA_JS_URL": lazy_static("altcha/altcha.min.js"),
     # URL of the Altcha translations JavaScript file.
     # Defaults to the bundled django-altcha file.
-    "ALTCHA_JS_TRANSLATIONS_URL": "/static/altcha/dist_i18n/all.min.js",
+    "ALTCHA_JS_TRANSLATIONS_URL": lazy_static("altcha/dist_i18n/all.min.js"),
     # Whether to include Altcha translations.
     # https://altcha.org/docs/v2/widget-integration/#internationalization-i18n
     "ALTCHA_INCLUDE_TRANSLATIONS": False,

--- a/django_altcha/utils.py
+++ b/django_altcha/utils.py
@@ -1,0 +1,20 @@
+# Django
+from django.templatetags.static import static
+
+
+def lazy_static(path):
+    """
+    Return a lazy proxy that resolves static(path) when stringified (e.g. in templates).
+    This is useful to avoid AppRegistryNotReady errors in settings.
+    """
+
+    class _LazyStaticUrl:
+        __slots__ = ("_path",)
+
+        def __init__(self, path):
+            self._path = path
+
+        def __str__(self):
+            return static(self._path)
+
+    return _LazyStaticUrl(path)

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -3,3 +3,4 @@ DATABASES = {"default": {"ENGINE": "django.db.backends.sqlite3"}}
 ROOT_URLCONF = "tests.urls"
 ALTCHA_HMAC_KEY = "altcha-insecure-hmac-0123456789abcdef"
 CACHES = {"default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"}}
+STATIC_URL = "/static/"


### PR DESCRIPTION
I found a small issue in the [default config](https://github.com/aboutcode-org/django-altcha/blob/main/django_altcha/conf.py#L30) where the static URLs are currently hardcoded  :

```
    # Defaults to the bundled django-altcha file.
    "ALTCHA_JS_URL": "/static/altcha/altcha.min.js",
    # URL of the Altcha translations JavaScript file.
    # Defaults to the bundled django-altcha file.
    "ALTCHA_JS_TRANSLATIONS_URL": "/static/altcha/dist_i18n/all.min.js",
```

To address this, I implemented a lazy static URL loader, which allows the use of Django's `static` template tag within this configuration.
