### PR TITLE
fix(deps): cap altcha at <2.0.0 for incompatible v2 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
 requires-python = ">=3.9"
 dependencies = [
     "Django>=4.2",
-    "altcha>=1.0.0",
+    "altcha>=1.0.0,<2.0.0",
 ]
 keywords = ["captcha", "django", "widget", "form", "altcha"]
 


### PR DESCRIPTION
Issue: https://github.com/aboutcode-org/django-altcha/issues/41